### PR TITLE
Add top picks of September 2025

### DIFF
--- a/2025/09.md
+++ b/2025/09.md
@@ -1,0 +1,92 @@
+# 📅 September 2025 - GitHub Gems
+
+> Our top picks for September 2025 — exceptional open source repositories that deserve more attention
+
+---
+
+## 🏆 Top 3 Picks
+
+### 🥇 #1 - eclaire
+**Repo:** [`etsd-tech/eclaire`](https://github.com/etsd-tech/eclaire)  
+**Language:** TypeScript  
+**Why it stands out:** A local-first, private AI assistant for all your personal data (notes, docs, bookmarks). Combines privacy, AI, and personal knowledge management into a single cohesive product with massive potential. This has enormous potential and targets a massive user desire for privacy and data ownership.
+
+**Highlights:**
+- Local-first architecture for complete privacy
+- AI assistant for personal knowledge management
+- Fantastic documentation and clear vision
+- MIT licensed and open source
+
+---
+
+### 🥈 #2 - resterm
+**Repo:** [`resterm/resterm`](https://github.com/resterm/resterm)  
+**Language:** Rust  
+**Why it stands out:** A beautifully executed and highly practical TUI for API testing that brings Postman/Insomnia functionality to the terminal. Comprehensive support for HTTP, gRPC, and more with excellent documentation. A perfect gem for any developer who loves the command line.
+
+**Highlights:**
+- Complete API testing in the terminal
+- Supports HTTP, gRPC, and multiple protocols
+- Professional presentation and documentation
+- Perfect for developers who live in the CLI
+
+---
+
+### 🥉 #3 - react-native-nitro-fetch
+**Repo:** [`margelo/react-native-nitro-fetch`](https://github.com/margelo/react-native-nitro-fetch)  
+**Language:** TypeScript  
+**Why it stands out:** A production-ready solution to a real, expensive business problem (mobile app network speed). Solves a critical performance problem in React Native by using native components for network requests. Well-documented, MIT-licensed, and built for production by a reputable organization.
+
+**Highlights:**
+- Significant performance boost using native components (Cronet)
+- Production-ready and battle-tested
+- From reputable organization (Margelo)
+- Solves real-world performance issues
+
+---
+
+## 🔖 Honorable Mentions
+
+### thoth-blueprint
+**Repo:** [`thoth-tech/thoth-blueprint`](https://github.com/thoth-tech/thoth-blueprint)  
+**Language:** TypeScript  
+**Why it stands out:** A feature-rich, free, and offline-first visual database designer that works as a PWA and generates migrations. Immediately useful for any developer or team with professional presentation. A perfect example of a high-quality FOSS tool.
+
+---
+
+### CodeMachine-CLI
+**Repo:** [`CodeMachine-LLC/CodeMachine-CLI`](https://github.com/CodeMachine-LLC/CodeMachine-CLI)  
+**Language:** Python  
+**Why it stands out:** Ambitious project automating code generation from specs using multi-agent AI. Excellent documentation tackling a high-value business problem with powerful scaffolding and automation capabilities. If it can mature to reliably deliver on its promise of "specs-to-code" automation, it represents a true paradigm shift in developer productivity.
+
+---
+
+## 📊 Summary Stats
+
+- **Repositories evaluated:** 1000+
+- **Final selections:** 5
+- **Languages:** TypeScript (3), Rust (1), Python (1)
+- **Themes:** AI/ML, Privacy, Developer Tools, Performance, Automation
+
+---
+
+## 🔍 How We Picked These
+
+We curated this list using:
+- **Comprehensive quality scoring** across multiple dimensions
+- **Business value assessment** for practical applicability
+- **Innovation evaluation** for technical advancement
+- **Production readiness** analysis for real-world deployment
+- **Documentation quality** review for user experience
+
+**Summary Insights:**
+- **Most Innovative:** eclaire - Combines local-first, PKM, and AI into a privacy-focused product
+- **Best Documentation:** eclaire - Exceptionally clear, well-structured README
+- **Most Production-Ready:** react-native-nitro-fetch - Battle-tested library solving real performance issues
+- **Biggest Potential:** CodeMachine-CLI - Could represent a paradigm shift in developer productivity
+
+---
+
+## 💡 Got a hidden gem?
+
+Suggest projects for next month by [opening an issue](https://github.com/sergioalmela/underrated-github-gems/issues) or submitting a [pull request](https://github.com/sergioalmela/underrated-github-gems/pulls).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ✨ Awesome GitHub Gems
+# Awesome GitHub Gems
 
-> 🪄 A curated monthly list of **underrated GitHub repositories** — beautifully crafted projects with under 500 stars you’ve probably never seen.
+> A curated monthly list of **underrated GitHub repositories** — beautifully crafted projects with under 500 stars you’ve probably never seen.
 
 Each month we dig deep using advanced GitHub search to uncover **high-quality**, **well-documented**, and often overlooked gems across languages and domains.
 
@@ -12,13 +12,13 @@ Whether you're a developer, designer, hacker, or curious explorer — this list 
 
 > 👇 Our **Top 3 GitHub Gems** for:
 
-### 📅 August 2025
+### 📅 September 2025
 
 | Rank | Project | Description | Language | Category |
 |------|---------|-------------|----------| ---------|
-| 🥇 1 | [`sinkzone`](https://github.com/sinkzone/sinkzone) | Outstanding productivity tool using allowlist-only DNS to block distractions | Go | Productivity / Security |
-| 🥈 2 | [`PocketChest`](https://github.com/PocketChest/PocketChest) | Beautifully executed serverless file and text sharing on Cloudflare | TypeScript | File Sharing / Serverless |
-| 🥉 3 | [`MiroFlow`](https://github.com/MiroFlow/MiroFlow) | Excellent framework for building complex, multi-agent AI systems | Python | AI / Multi-Agent Systems |
+| 🥇 1 | [`eclaire`](https://github.com/etsd-tech/eclaire) | Local-first, private AI assistant for personal knowledge management | TypeScript | AI / Privacy |
+| 🥈 2 | [`resterm`](https://github.com/resterm/resterm) | Outstanding TUI for API testing (Postman/Insomnia for the terminal) | Rust | Developer Tools / CLI |
+| 🥉 3 | [`react-native-nitro-fetch`](https://github.com/margelo/react-native-nitro-fetch) | Production-ready solution for fast network requests in React Native | TypeScript | Performance / Mobile |
 
 ---
 
@@ -26,8 +26,8 @@ Whether you're a developer, designer, hacker, or curious explorer — this list 
 
 | Project | Description | Language |
 |---------|-------------|----------|
-| [`markdown-ui`](https://github.com/markdown-ui/markdown-ui) | Open standard for interactive widgets in Markdown | JavaScript |
-| [`Matrix-3D`](https://github.com/Matrix-3D/Matrix-3D) | Cutting-edge AI creating explorable 3D scenes from single images | Python |
+| [`thoth-blueprint`](https://github.com/thoth-tech/thoth-blueprint) | Free, offline-first visual database designer with migration generation | TypeScript |
+| [`CodeMachine-CLI`](https://github.com/CodeMachine-LLC/CodeMachine-CLI) | AI-powered code generation from specs using multi-agent systems | Python |
 
 ---
 
@@ -39,17 +39,18 @@ Every month gets its own page with **details**, **screenshots**, and **why it’
 |-------|------|
 | 📅 July 2025 | [`/2025/07.md`](./2025/07.md) |
 | 📅 August 2025 | [`/2025/08.md`](./2025/08.md) |
+| 📅 September 2025 | [`/2025/09.md`](./2025/09.md) |
 
 ---
 
-## 📊 How We Pick Gems
+## How We Pick Gems
 
 We look for:
 
-- ⭐ Less than **500 stars**
-- 💡 Original ideas or clever execution
-- 📖 Great documentation or clean UX
-- 🔄 Actively maintained and usable
+- Less than **500 stars**
+- Original ideas or clever execution
+- Great documentation or clean UX
+- Actively maintained and usable
 
 No low-effort projects. No abandoned ideas. Just pure dev joy.
 
@@ -62,7 +63,7 @@ If your project was featured as a Hidden Gem, add this badge to your README:
   ```markdown
   [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-August%202025-blueviolet?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
   ```
-  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-August%202025-red?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
+  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-September%202025-red?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
 
 ---
 
@@ -80,8 +81,8 @@ Help us grow the list:
 
 If you like what we’re doing:
 
-- ⭐ Star this repo
-- 🐦 Share on [Twitter/X](https://twitter.com/)
-- 🧑‍💻 Mention us in your blog or dev community
+- Star this repo
+- Share on [Twitter/X](https://twitter.com/)
+- Mention us in your blog or dev community
 
 Let’s help these gems shine ✨


### PR DESCRIPTION
This pull request updates the repository for the September 2025 edition of GitHub Gems, featuring new top picks and honorable mentions. The changes include adding a new monthly page, updating the README to reflect the September selections, and revising supporting documentation and badges. The most important changes are grouped below:

**September 2025 Edition Updates:**

* Added the new `2025/09.md` page, listing the top 3 picks (`eclaire`, `resterm`, `react-native-nitro-fetch`) and two honorable mentions (`thoth-blueprint`, `CodeMachine-CLI`), with detailed descriptions, highlights, and selection methodology.
* Updated the main README to reflect September 2025 as the current month, replacing August’s featured projects and honorable mentions with the new selections.

**Documentation and Navigation Improvements:**

* Added navigation to the new September 2025 page in the README’s monthly index.
* Updated the badge example for featured projects to reference September 2025 instead of August.