### PR TITLE
Add top picks of October 2025

### DIFF
--- a/2025/10.md
+++ b/2025/10.md
@@ -1,0 +1,92 @@
+# 📅 October 2025 - GitHub Gems
+
+> Our top picks for October 2025 — exceptional open source repositories that deserve more attention
+
+---
+
+## 🏆 Top 3 Picks
+
+### 🥇 #1 - deepseek-ocr.rs
+**Repo:** [`ShelbyJenkins/deepseek-ocr.rs`](https://github.com/ShelbyJenkins/deepseek-ocr.rs)  
+**Language:** Rust  
+**Why it stands out:** A perfect example of an underrated gem. It ports the powerful DeepSeek-OCR model to Rust, completely removing the heavy Python dependencies. This results in a single, high-performance binary that is incredibly easy to deploy and "just works."
+
+**Highlights:**
+- Single, dependency-free binary
+- High-performance Rust implementation
+- Removes heavy Python dependencies
+- Trivial to deploy and use instantly
+
+---
+
+### 🥈 #2 - OpenMemory
+**Repo:** [`plastic-labs/OpenMemory`](https://github.com/plastic-labs/OpenMemory)  
+**Language:** TypeScript  
+**Why it stands out:** An excellent, self-hosted service for adding long-term memory to any AI, in any framework. The documentation is extensive and clear, and it solves the critical "memory" problem in a practical, production-ready way. Could become a foundational piece of the next generation of AI applications.
+
+**Highlights:**
+- Self-hosted memory service for AI agents
+- Framework-agnostic solution
+- Extensive and clear documentation
+- Production-ready implementation
+
+---
+
+### 🥉 #3 - nginx-love
+**Repo:** [`nginx-love/nginx-love`](https://github.com/nginx-love/nginx-love)  
+**Language:** PHP  
+**Why it stands out:** A fantastic open-source project providing a much-needed management portal for Nginx and ModSecurity (WAF). This is a high-value, practical tool for DevOps and sysadmins, is well-documented, and has a permissive Apache 2.0 license.
+
+**Highlights:**
+- FOSS management UI for Nginx + WAF
+- High practical value for DevOps teams
+- Well-documented with Apache 2.0 license
+- Critical infrastructure management tool
+
+---
+
+## 🔖 Honorable Mentions
+
+### oxdraw
+**Repo:** [`oxdraw/oxdraw`](https://github.com/oxdraw/oxdraw)  
+**Language:** TypeScript  
+**Why it stands out:** A fantastic concept: a "diagram as code" tool that also allows for draggable visual editing. This hybrid approach solves a major pain point of text-only tools. High-potential utility for any developer or architect.
+
+---
+
+### arc
+**Repo:** [`mosmeh/arc`](https://github.com/mosmeh/arc)  
+**Language:** Rust  
+**Why it stands out:** A high-performance time-series data warehouse built on a modern stack (DuckDB, Parquet, Arrow). It is exceptionally well-documented (55k+ chars) and solves a high-value business problem. The AGPL license is a key consideration, but the project quality is top-tier.
+
+---
+
+## 📊 Summary Stats
+
+- **Repositories evaluated:** 1000+
+- **Final selections:** 5
+- **Languages:** Rust (2), TypeScript (2), PHP (1)
+- **Themes:** Performance, AI/ML, Infrastructure, Developer Tools, Data
+
+---
+
+## 🔍 How We Picked These
+
+We curated this list using:
+- **Comprehensive quality scoring** across multiple dimensions
+- **Business value assessment** for practical applicability
+- **Innovation evaluation** for technical advancement
+- **Production readiness** analysis for real-world deployment
+- **Documentation quality** review for user experience
+
+**Summary Insights:**
+- **Most Innovative:** proofofthought - Combines LLMs with Z3 theorem provers for verifiable AI reasoning
+- **Most Production-Ready:** deepseek-ocr.rs - Single binary, dependency-free, and ready to deploy
+- **Best Documentation:** arc - 55,000+ character README covering architecture, setup, and performance
+- **Biggest Potential:** OpenMemory - Solves the fundamental "memory" problem for AI agents
+
+---
+
+## 💡 Got a hidden gem?
+
+Suggest projects for next month by [opening an issue](https://github.com/sergioalmela/underrated-github-gems/issues) or submitting a [pull request](https://github.com/sergioalmela/underrated-github-gems/pulls).

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Whether you're a developer, designer, hacker, or curious explorer — this list 
 
 > 👇 Our **Top 3 GitHub Gems** for:
 
-### 📅 September 2025
+### 📅 October 2025
 
 | Rank | Project | Description | Language | Category |
 |------|---------|-------------|----------| ---------|
-| 🥇 1 | [`eclaire`](https://github.com/etsd-tech/eclaire) | Local-first, private AI assistant for personal knowledge management | TypeScript | AI / Privacy |
-| 🥈 2 | [`resterm`](https://github.com/resterm/resterm) | Outstanding TUI for API testing (Postman/Insomnia for the terminal) | Rust | Developer Tools / CLI |
-| 🥉 3 | [`react-native-nitro-fetch`](https://github.com/margelo/react-native-nitro-fetch) | Production-ready solution for fast network requests in React Native | TypeScript | Performance / Mobile |
+| 🥇 1 | [`deepseek-ocr.rs`](https://github.com/ShelbyJenkins/deepseek-ocr.rs) | Rust port of DeepSeek-OCR as a single, dependency-free binary | Rust | Performance / OCR |
+| 🥈 2 | [`OpenMemory`](https://github.com/plastic-labs/OpenMemory) | Self-hosted long-term memory service for AI agents | TypeScript | AI / Memory |
+| 🥉 3 | [`nginx-love`](https://github.com/nginx-love/nginx-love) | Management portal for Nginx and ModSecurity (WAF) | PHP | Infrastructure / DevOps |
 
 ---
 
@@ -26,8 +26,8 @@ Whether you're a developer, designer, hacker, or curious explorer — this list 
 
 | Project | Description | Language |
 |---------|-------------|----------|
-| [`thoth-blueprint`](https://github.com/thoth-tech/thoth-blueprint) | Free, offline-first visual database designer with migration generation | TypeScript |
-| [`CodeMachine-CLI`](https://github.com/CodeMachine-LLC/CodeMachine-CLI) | AI-powered code generation from specs using multi-agent systems | Python |
+| [`oxdraw`](https://github.com/oxdraw/oxdraw) | Diagram as code tool with draggable visual editing | TypeScript |
+| [`arc`](https://github.com/mosmeh/arc) | High-performance time-series warehouse on modern data stack | Rust |
 
 ---
 
@@ -40,6 +40,7 @@ Every month gets its own page with **details**, **screenshots**, and **why it’
 | 📅 July 2025 | [`/2025/07.md`](./2025/07.md) |
 | 📅 August 2025 | [`/2025/08.md`](./2025/08.md) |
 | 📅 September 2025 | [`/2025/09.md`](./2025/09.md) |
+| 📅 October 2025 | [`/2025/10.md`](./2025/10.md) |
 
 ---
 
@@ -61,9 +62,9 @@ No low-effort projects. No abandoned ideas. Just pure dev joy.
 If your project was featured as a Hidden Gem, add this badge to your README:
 
   ```markdown
-  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-August%202025-blueviolet?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
+  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-October%202025-blueviolet?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
   ```
-  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-September%202025-red?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
+  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-October%202025-red?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
 
 ---
 


### PR DESCRIPTION
This pull request updates the repository to feature the top GitHub Gems for October 2025. It introduces a new detailed monthly page for October, updates the featured projects and honorable mentions in the main `README.md`, and refreshes badge references for the new month. The changes ensure the project highlights the latest and most relevant open source repositories.

**Featured Projects and Monthly Update:**

* Added a new page `2025/10.md` with detailed write-ups for October 2025’s top picks, honorable mentions, summary stats, and selection methodology.
* Updated the main list in `README.md` to showcase October 2025’s top 3 projects and honorable mentions, replacing September’s entries.
* Linked the new October 2025 page in the monthly navigation table in `README.md`.