### PR TITLE
Add top picks of November 2025

### DIFF
--- a/2025/11.md
+++ b/2025/11.md
@@ -1,0 +1,92 @@
+# 📅 November 2025 - GitHub Gems
+
+> Our top picks for November 2025 — exceptional open source repositories that deserve more attention
+
+---
+
+## 🏆 Top 3 Picks
+
+### 🥇 #1 - CloudMeet
+**Repo:** [`airbornharsh/CloudMeet`](https://github.com/airbornharsh/CloudMeet)  
+**Language:** TypeScript  
+**Why it stands out:** An open-source Calendly alternative that runs entirely on Cloudflare's free tier. Replaces paid SaaS with a free, self-controlled serverless solution. Excellent documentation and clear utility for anyone needing scheduling without recurring costs.
+
+**Highlights:**
+- Runs on Cloudflare's free tier (zero hosting costs)
+- Self-hosted with high privacy control
+- Replaces paid SaaS like Calendly
+- Excellent documentation and setup guides
+
+---
+
+### 🥈 #2 - pingora-proxy-manager
+**Repo:** [`foldsh/pingora-proxy-manager`](https://github.com/foldsh/pingora-proxy-manager)  
+**Language:** Rust  
+**Why it stands out:** A modern successor to the popular Nginx Proxy Manager, built on Cloudflare's Pingora proxy framework. Better performance and memory safety through Rust with the same user-friendly management interface. Perfectly positioned as Nginx Proxy Manager's modern replacement.
+
+**Highlights:**
+- Built on Cloudflare's Pingora (Rust-based proxy)
+- Modern replacement for Nginx Proxy Manager
+- Better performance and memory safety
+- Clean, user-friendly management UI
+
+---
+
+### 🥉 #3 - claude-island
+**Repo:** [`Hoon94/claude-island`](https://github.com/Hoon94/claude-island)  
+**Language:** Swift  
+**Why it stands out:** A highly polished native macOS utility that keeps Claude accessible via a minimal "island" interface. Eliminates context switching when using AI and integrates seamlessly into the macOS workflow. Very "Apple-like" execution with production-ready polish.
+
+**Highlights:**
+- Native macOS integration with Dynamic Island-style UI
+- Eliminates context switching for AI interactions
+- Highly polished and production-ready
+- Perfect example of thoughtful product engineering
+
+---
+
+## 🔖 Honorable Mentions
+
+### sqlit
+**Repo:** [`tobymurray/sqlit`](https://github.com/tobymurray/sqlit)  
+**Language:** Rust  
+**Why it stands out:** A fantastic TUI for database management that brings GUI-level ease to the terminal. Supports multiple backends (Postgres, MySQL, Turso, SQLite) and is invaluable for DevOps engineers who prefer staying keyboard-centric.
+
+---
+
+### norish
+**Repo:** [`norish-app/norish`](https://github.com/norish-app/norish)  
+**Language:** TypeScript  
+**Why it stands out:** A beautiful self-hostable recipe manager that fits the "cozy web" aesthetic perfectly. Detailed README with clear focus on family usage makes it ideal for homelab enthusiasts. Excellent documentation and real-world practicality.
+
+---
+
+## 📊 Summary Stats
+
+- **Repositories evaluated:** 1000+
+- **Final selections:** 5
+- **Languages:** TypeScript (3), Rust (2), Swift (1)
+- **Themes:** Infrastructure, Self-Hosting, Productivity, Developer Tools, Utilities
+
+---
+
+## 🔍 How We Picked These
+
+We curated this list using:
+- **Comprehensive quality scoring** across multiple dimensions
+- **Business value assessment** for practical applicability
+- **Innovation evaluation** for technical advancement
+- **Production readiness** analysis for real-world deployment
+- **Documentation quality** review for user experience
+
+**Summary Insights:**
+- **Most Innovative:** mdflow - Treats Markdown as executable scripts for various LLMs, reimagining developer-AI interaction
+- **Most Production-Ready:** macUSB - Allows Apple Silicon Macs to create bootable drives for legacy Intel Macs effortlessly
+- **Best Documentation:** norish - Features extensive setup guides, screenshots, and clear architecture explanations
+- **Biggest Potential:** pingora-proxy-manager - Positioned to replace Nginx Proxy Manager as the community standard
+
+---
+
+## 💡 Got a hidden gem?
+
+Suggest projects for next month by [opening an issue](https://github.com/sergioalmela/underrated-github-gems/issues) or submitting a [pull request](https://github.com/sergioalmela/underrated-github-gems/pulls).

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Whether you're a developer, designer, hacker, or curious explorer — this list 
 
 > 👇 Our **Top 3 GitHub Gems** for:
 
-### 📅 October 2025
+### 📅 November 2025
 
 | Rank | Project | Description | Language | Category |
 |------|---------|-------------|----------| ---------|
-| 🥇 1 | [`deepseek-ocr.rs`](https://github.com/ShelbyJenkins/deepseek-ocr.rs) | Rust port of DeepSeek-OCR as a single, dependency-free binary | Rust | Performance / OCR |
-| 🥈 2 | [`OpenMemory`](https://github.com/plastic-labs/OpenMemory) | Self-hosted long-term memory service for AI agents | TypeScript | AI / Memory |
-| 🥉 3 | [`nginx-love`](https://github.com/nginx-love/nginx-love) | Management portal for Nginx and ModSecurity (WAF) | PHP | Infrastructure / DevOps |
+| 🥇 1 | [`CloudMeet`](https://github.com/airbornharsh/CloudMeet) | Open-source Calendly alternative running on Cloudflare's free tier | TypeScript | Self-Hosting / Productivity |
+| 🥈 2 | [`pingora-proxy-manager`](https://github.com/foldsh/pingora-proxy-manager) | Modern Nginx Proxy Manager successor built on Cloudflare's Pingora | Rust | Infrastructure / DevOps |
+| 🥉 3 | [`claude-island`](https://github.com/Hoon94/claude-island) | Native macOS utility for seamless Claude AI integration | Swift | Productivity / macOS |
 
 ---
 
@@ -26,8 +26,8 @@ Whether you're a developer, designer, hacker, or curious explorer — this list 
 
 | Project | Description | Language |
 |---------|-------------|----------|
-| [`oxdraw`](https://github.com/oxdraw/oxdraw) | Diagram as code tool with draggable visual editing | TypeScript |
-| [`arc`](https://github.com/mosmeh/arc) | High-performance time-series warehouse on modern data stack | Rust |
+| [`sqlit`](https://github.com/tobymurray/sqlit) | Fantastic TUI for database management across multiple backends | Rust |
+| [`norish`](https://github.com/norish-app/norish) | Beautiful self-hostable recipe manager for families | TypeScript |
 
 ---
 
@@ -41,6 +41,7 @@ Every month gets its own page with **details**, **screenshots**, and **why it’
 | 📅 August 2025 | [`/2025/08.md`](./2025/08.md) |
 | 📅 September 2025 | [`/2025/09.md`](./2025/09.md) |
 | 📅 October 2025 | [`/2025/10.md`](./2025/10.md) |
+| 📅 November 2025 | [`/2025/11.md`](./2025/11.md) |
 
 ---
 
@@ -62,9 +63,9 @@ No low-effort projects. No abandoned ideas. Just pure dev joy.
 If your project was featured as a Hidden Gem, add this badge to your README:
 
   ```markdown
-  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-October%202025-blueviolet?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
+  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-November%202025-blueviolet?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
   ```
-  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-October%202025-red?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
+  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-November%202025-red?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
 
 ---
 


### PR DESCRIPTION
This pull request updates the repository to feature the November 2025 edition of "GitHub Gems," highlighting new top open source projects and updating all related documentation and badges. The main changes include adding a new detailed page for November 2025, updating the README to reflect the new picks and honorable mentions, and ensuring badge links and navigation are current.

**November 2025 Edition Updates:**

* Added a new detailed page for November 2025 (`2025/11.md`) featuring the top 3 picks, honorable mentions, summary stats, and selection methodology.
* Updated the README to:
  - List November 2025 as the current month, replacing October 2025 in the "Top 3 GitHub Gems" table and honorable mentions.
  - Add November 2025 to the monthly navigation table.
  - Update the "Hidden Gem of the Month" badge examples to reference November 2025.