### PR TITLE
Add top picks of December 2025

### DIFF
--- a/2025/12.md
+++ b/2025/12.md
@@ -1,0 +1,92 @@
+# 📅 December 2025 - GitHub Gems
+
+> Our top picks for December 2025 — exceptional open source repositories that deserve more attention
+
+---
+
+## 🏆 Top 3 Picks
+
+### 🥇 #1 - boxlite
+**Repo:** [`boxlite-ai/boxlite`](https://github.com/boxlite-ai/boxlite)  
+**Language:** Rust  
+**Why it stands out:** A revolutionary micro-VM sandbox that embeds like SQLite for AI agent security. Solves the critical problem of running untrusted AI-generated code with hardware-level isolation. OCI compatible, cross-platform, and has 11 releases showing active development. This addresses a pressing industry need with elegant architecture.
+
+**Highlights:**
+- Hardware-level isolation for AI agents
+- Embeds like SQLite with simple API
+- OCI compatible and cross-platform
+- Well-documented architecture
+
+---
+
+### 🥈 #2 - drip
+**Repo:** [`Gouryella/drip`](https://github.com/Gouryella/drip)  
+**Language:** Go  
+**Why it stands out:** The best self-hosted ngrok alternative with TLS 1.3, unlimited bandwidth, and one-line installation. Professional documentation with clear comparison tables and well-structured codebase. Perfect for developers needing localhost tunneling without relying on third-party services.
+
+**Highlights:**
+- Self-hosted with TLS 1.3 support
+- Unlimited bandwidth and connections
+- One-line installation process
+- Clear comparison with ngrok
+
+---
+
+### 🥉 #3 - stoolap
+**Repo:** [`stoolap/stoolap`](https://github.com/stoolap/stoolap)  
+**Language:** Rust  
+**Why it stands out:** An ambitious embedded SQL database in Rust featuring MVCC transactions, time-travel queries, and multiple index types. Comprehensive documentation and published on crates.io with proper versioning. Could become a serious SQLite alternative for applications needing advanced query features.
+
+**Highlights:**
+- MVCC transactions and time-travel queries
+- Multiple index types (B+Tree, Hash, LSM)
+- Published on crates.io
+- Comprehensive SQL support
+
+---
+
+## 🔖 Honorable Mentions
+
+### Rackula
+**Repo:** [`RackulaLives/Rackula`](https://github.com/RackulaLives/Rackula)  
+**Language:** TypeScript  
+**Why it stands out:** A drag-and-drop server rack visualizer with Docker support and QR code sharing. Perfect for homelab enthusiasts with NetBox device library compatibility and PNG/PDF/SVG export options. Makes documenting your infrastructure setup actually enjoyable.
+
+---
+
+### mdflow
+**Repo:** [`johnlindquist/mdflow`](https://github.com/johnlindquist/mdflow)  
+**Language:** TypeScript  
+**Why it stands out:** Executable markdown prompts for Claude, Codex, Gemini, and Copilot. Created by the maker of Script Kit with 42 releases showing active maintenance. Treats markdown files as executable scripts, following Unix philosophy design.
+
+---
+
+## 📊 Summary Stats
+
+- **Repositories evaluated:** 1000+
+- **Final selections:** 5
+- **Languages:** Rust (2), TypeScript (2), Go (1)
+- **Themes:** Security, Infrastructure, Developer Tools, Visualization, Databases
+
+---
+
+## 🔍 How We Picked These
+
+We curated this list using:
+- **Comprehensive quality scoring** across multiple dimensions
+- **Business value assessment** for practical applicability
+- **Innovation evaluation** for technical advancement
+- **Production readiness** analysis for real-world deployment
+- **Documentation quality** review for user experience
+
+**Summary Insights:**
+- **Most Innovative:** boxlite - Micro-VM sandboxes that embed like SQLite represent a novel approach to AI agent security
+- **Most Production-Ready:** drip - Immediately deployable as ngrok replacement with 7 releases and comprehensive documentation
+- **Best Documentation:** AnyTool - Exceptionally thorough with detailed architecture diagrams and configuration guides
+- **Biggest Potential:** stoolap - Could become a serious SQLite alternative for applications needing MVCC and advanced features
+
+---
+
+## 💡 Got a hidden gem?
+
+Suggest projects for next month by [opening an issue](https://github.com/sergioalmela/underrated-github-gems/issues) or submitting a [pull request](https://github.com/sergioalmela/underrated-github-gems/pulls).

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Whether you're a developer, designer, hacker, or curious explorer — this list 
 
 > 👇 Our **Top 3 GitHub Gems** for:
 
-### 📅 November 2025
+### 📅 December 2025
 
 | Rank | Project | Description | Language | Category |
 |------|---------|-------------|----------| ---------|
-| 🥇 1 | [`CloudMeet`](https://github.com/dennisklappe/CloudMeet) | Open-source Calendly alternative running on Cloudflare's free tier | TypeScript | Self-Hosting / Productivity |
-| 🥈 2 | [`pingora-proxy-manager`](https://github.com/DDULDDUCK/pingora-proxy-manager) | Modern Nginx Proxy Manager successor built on Cloudflare's Pingora | Rust | Infrastructure / DevOps |
-| 🥉 3 | [`claude-island`](https://github.com/farouqaldori/claude-island) | Native macOS utility for seamless Claude AI integration | Swift | Productivity / macOS |
+| 🥇 1 | [`boxlite`](https://github.com/boxlite-ai/boxlite) | Micro-VM sandbox for AI agents that embeds like SQLite | Rust | Security / AI |
+| 🥈 2 | [`drip`](https://github.com/Gouryella/drip) | Self-hosted ngrok alternative with TLS 1.3 and unlimited bandwidth | Go | Infrastructure / DevOps |
+| 🥉 3 | [`stoolap`](https://github.com/stoolap/stoolap) | Embedded SQL database in Rust with MVCC and time-travel queries | Rust | Databases |
 
 ---
 
@@ -26,8 +26,8 @@ Whether you're a developer, designer, hacker, or curious explorer — this list 
 
 | Project | Description | Language |
 |---------|-------------|----------|
-| [`sqlit`](https://github.com/Maxteabag/sqlit) | Fantastic TUI for database management across multiple backends | Rust |
-| [`norish`](https://github.com/norish-recipes/norish) | Beautiful self-hostable recipe manager for families | TypeScript |
+| [`Rackula`](https://github.com/RackulaLives/Rackula) | Drag-and-drop server rack visualizer with Docker support | TypeScript |
+| [`mdflow`](https://github.com/johnlindquist/mdflow) | Executable markdown prompts for Claude, Codex, Gemini, and Copilot | TypeScript |
 
 ---
 
@@ -42,6 +42,7 @@ Every month gets its own page with **details**, **screenshots**, and **why it’
 | 📅 September 2025 | [`/2025/09.md`](./2025/09.md) |
 | 📅 October 2025 | [`/2025/10.md`](./2025/10.md) |
 | 📅 November 2025 | [`/2025/11.md`](./2025/11.md) |
+| 📅 December 2025 | [`/2025/12.md`](./2025/12.md) |
 
 ---
 
@@ -63,9 +64,9 @@ No low-effort projects. No abandoned ideas. Just pure dev joy.
 If your project was featured as a Hidden Gem, add this badge to your README:
 
   ```markdown
-  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-November%202025-blueviolet?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
+  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-December%202025-blueviolet?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
   ```
-  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-November%202025-red?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
+  [![Hidden Gem of the Month](https://img.shields.io/badge/🚀%20Hidden%20Gem-December%202025-red?style=for-the-badge)](https://github.com/sergioalmela/underrated-github-gems)
 
 ---
 


### PR DESCRIPTION
This pull request updates the repository for December 2025, featuring a new selection of top open source projects and updating all related documentation and badges. The most important changes are:

**December 2025 Feature Update:**

* Added a new monthly highlights page `2025/12.md` with detailed write-ups on the top 3 picks (boxlite, drip, stoolap), honorable mentions, summary stats, and methodology.
* Updated the main project table in `README.md` to showcase the December 2025 top 3 projects and honorable mentions, replacing the previous month's selections.

**Documentation & Navigation:**

* Added a link to the new December 2025 details page in the monthly navigation table in `README.md`.

**Badge & Branding:**

* Updated the "Hidden Gem of the Month" badge examples in `README.md` to reference December 2025 instead of November 2025.